### PR TITLE
Support ssh:// URL format for remote origin

### DIFF
--- a/plugin/github-url.vim
+++ b/plugin/github-url.vim
@@ -12,7 +12,7 @@ function! s:repoURL()
     echo "Warning: Could not determine remote from '" . branch . "', assuming origin"
     let remote = "origin"
   endif
-  let repo = systemlist("git config --get remote." . remote . ".url | sed 's/\.git$//' | sed 's_^git@\\(.*\\):_https://\\1/_' | sed 's_^git://_https://_'")[0]
+  let repo = systemlist("git config --get remote." . remote . ".url | sed 's/\.git$//' | sed 's_^git@\\(.*\\):_https://\\1/_' | sed 's_^git://_https://_' | sed 's_^ssh://git@_https://_'")[0]
 
   return repo
 endfunction


### PR DESCRIPTION
  ## Summary
  - Add support for `ssh://git@host/path` URL format when converting remote URLs to HTTPS

  ## Background
  The plugin previously only handled the SCP-style format (`git@host:path`), but some tools use the SSH URL format (`ssh://git@host/path`). This caused URLs
  like `ssh://git@github.com/user/repo` to be output as-is instead of being converted to `https://github.com/user/repo`.

  ## Changes
  Added a sed substitution to convert `ssh://git@` prefix to `https://` in the `s:repoURL()` function.